### PR TITLE
Fix bug with unsaved changes warning not triggering in forms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 *.swp szFwdAdsI6
-.DS_Store gzp4S7sKLj
+.DS_Store
  WAb9BPYdU0


### PR DESCRIPTION
Resolved issues causing unsaved changes warnings to fail in specific scenarios.